### PR TITLE
Move `react` and `react-dom` to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/jest": "^27.5.0",
     "@types/lodash": "^4.14.182",
     "@types/react": "^18.0.8",
-    "@types/react-dom": "^18.0.5",
     "@typescript-eslint/eslint-plugin": "^5.30.6",
     "@typescript-eslint/parser": "^5.30.6",
     "cpy-cli": "3.1.1",
@@ -55,6 +54,8 @@
     "flowgen": "^1.19.0",
     "jest": "^27.5.1",
     "prettier": "^2.6.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.4",
     "watch": "^1.0.2"
@@ -62,8 +63,6 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "flow-bin": "0.110.0",
-    "invariant": "^2.2.4",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "invariant": "^2.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freckle/react-hooks",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "React hooks used at Freckle",
   "main": "dist/index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,13 +1517,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^18.0.5":
-  version "18.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
-  integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*":
   version "18.0.9"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.9.tgz#d6712a38bd6cd83469603e7359511126f122e878"


### PR DESCRIPTION
`react` and `react-dom` are only needed to run Jest tests. Otherwise, `react` is expected to be provided from the existing peer dependency in consumer packages.