### PR TITLE
Use branded type for CallbackFn

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,5 +3,5 @@ export type { PrimitiveDep, CallbackFn, ExtraDeps } from './use-extra-deps';
 export { useSafeEffect, useSafeEffectExtraDeps } from './use-safe-effect';
 export { useSafeCallback, useSafeCallbackExtraDeps } from './use-safe-callback';
 export { usePrevious } from './use-previous';
-export { unCallbackFn, unsafeMkCallbackFn, useExtraDeps } from './use-extra-deps';
+export { unsafeMkCallbackFn, useExtraDeps } from './use-extra-deps';
 export { useSafeImperativeHandle, useSafeImperativeHandleExtraDeps } from './use-safe-imperative-handle';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useSafeImperativeHandleExtraDeps = exports.useSafeImperativeHandle = exports.useExtraDeps = exports.unsafeMkCallbackFn = exports.unCallbackFn = exports.usePrevious = exports.useSafeCallbackExtraDeps = exports.useSafeCallback = exports.useSafeEffectExtraDeps = exports.useSafeEffect = void 0;
+exports.useSafeImperativeHandleExtraDeps = exports.useSafeImperativeHandle = exports.useExtraDeps = exports.unsafeMkCallbackFn = exports.usePrevious = exports.useSafeCallbackExtraDeps = exports.useSafeCallback = exports.useSafeEffectExtraDeps = exports.useSafeEffect = void 0;
 var use_safe_effect_1 = require("./use-safe-effect");
 Object.defineProperty(exports, "useSafeEffect", { enumerable: true, get: function () { return use_safe_effect_1.useSafeEffect; } });
 Object.defineProperty(exports, "useSafeEffectExtraDeps", { enumerable: true, get: function () { return use_safe_effect_1.useSafeEffectExtraDeps; } });
@@ -10,7 +10,6 @@ Object.defineProperty(exports, "useSafeCallbackExtraDeps", { enumerable: true, g
 var use_previous_1 = require("./use-previous");
 Object.defineProperty(exports, "usePrevious", { enumerable: true, get: function () { return use_previous_1.usePrevious; } });
 var use_extra_deps_1 = require("./use-extra-deps");
-Object.defineProperty(exports, "unCallbackFn", { enumerable: true, get: function () { return use_extra_deps_1.unCallbackFn; } });
 Object.defineProperty(exports, "unsafeMkCallbackFn", { enumerable: true, get: function () { return use_extra_deps_1.unsafeMkCallbackFn; } });
 Object.defineProperty(exports, "useExtraDeps", { enumerable: true, get: function () { return use_extra_deps_1.useExtraDeps; } });
 var use_safe_imperative_handle_1 = require("./use-safe-imperative-handle");

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -1,17 +1,87 @@
-// @flow
+/* @flow */
 
-export type { MaybeCleanUpFn } from "./types.js";
+import * as React from "react";
 
-export type { PrimitiveDep, CallbackFn, ExtraDeps } from "./use-extra-deps";
-
-export { useSafeEffect, useSafeEffectExtraDeps } from "./use-safe-effect";
-
-export { useSafeCallback, useSafeCallbackExtraDeps } from "./use-safe-callback";
-
-export { usePrevious } from "./use-previous";
-
-export {
-  unCallbackFn,
-  unsafeMkCallbackFn,
+import {
+  type PrimitiveDep,
+  type ExtraDeps,
+  type CallbackFn,
   useExtraDeps,
-} from "./use-extra-deps";
+  unsafeMkCallbackFn,
+} from "./../use-extra-deps";
+
+export function useSafeCallback<F: (...Array<any>) => any>(
+  f: () => F,
+  deps: $ReadOnlyArray<PrimitiveDep>
+): CallbackFn<F> {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useSafeCallbackExtraDeps(() => f(), deps, {});
+}
+
+export function useSafeCallbackExtraDeps<
+  F: (...Array<any>) => any,
+  S: { [key: string]: any }
+>(
+  f: ($ObjMap<S, <V>(ExtraDeps<V>) => V>) => F,
+  deps: $ReadOnlyArray<PrimitiveDep>,
+  extraDeps: S
+): CallbackFn<F> {
+  const { extraDepValues, allDeps } = useExtraDeps(deps, extraDeps);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const cb = React.useCallback(f(extraDepValues), allDeps);
+
+  //$FlowFixMe: Can't unify `F` with useCallback but we know that they are the same
+  const cbF: F = cb;
+
+  return unsafeMkCallbackFn(cbF);
+} deps of `useEffect` et. al.
+//
+// By only allowing `PrimitiveDep`s in the `deps` array and forcing functions
+// and non-primitives through `extraDeps`, we can ensure that we are not doing
+// naive reference equality like React does for the `deps` array.
+//
+// See `useSafeEffect` for usage of this hook
+//
+// Returns an object based upon deps and extraDeps: { allDeps: An array that is
+// suitable to use as a deps array for things like `useEffect` , extraDepValues:
+// An object that has the same keys as extraDeps but contains their plain values
+// }
+//
+export function useExtraDeps<S: { [key: string]: any }>(
+  deps: $ReadOnlyArray<PrimitiveDep>,
+  extraDeps: S
+): {|
+  allDeps: $ReadOnlyArray<any>,
+  extraDepValues: $ObjMap<S, <V>(ExtraDeps<V>) => V>,
+|} {
+  const [run, setRun] = React.useState<Symbol>(Symbol());
+  const nonFnsRef = React.useRef(null);
+
+  const fns = pickBy(extraDeps, isFunction);
+  const nonFns = omitBy(extraDeps, isFunction);
+
+  const hasChange = () => {
+    if (nonFnsRef.current === null || nonFnsRef.current === undefined) {
+      return true;
+    }
+    for (const key in nonFns) {
+      if (
+        !nonFns[key].comparator(nonFns[key].value, nonFnsRef.current[key].value)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  if (hasChange()) {
+    setRun(Symbol());
+    nonFnsRef.current = nonFns;
+  }
+
+  return {
+    allDeps: [...deps, ...values(fns), run],
+    extraDepValues: { ...mapValues(nonFns, ({ value }) => value), ...fns },
+  };
+}

--- a/dist/use-extra-deps/index.d.ts
+++ b/dist/use-extra-deps/index.d.ts
@@ -1,16 +1,17 @@
-export declare type PrimitiveDep = boolean | string | number | null | void | symbol;
-export declare type CallbackFn<F> = {
-    callback: F;
+export declare type PrimitiveDep = boolean | string | number | null | void | symbol | CallbackFn<(...v: any) => any>;
+declare const __brand: unique symbol;
+export declare type CallbackFn<F> = F & {
+    [__brand]: "CallbackFn";
 };
-export declare const unCallbackFn: <F>({ callback }: CallbackFn<F>) => F;
 export declare function unsafeMkCallbackFn<F extends (...v: any) => any>(callback: F): CallbackFn<F>;
 export declare type ExtraDeps<V> = {
     value: V;
     comparator: (a: V, b: V) => boolean;
-} | CallbackFn<V>;
+};
 export declare function useExtraDeps<T extends Record<string, unknown>>(deps: ReadonlyArray<PrimitiveDep>, extraDeps: {
     [P in keyof T]: T[P] extends infer R ? ExtraDeps<R> : never;
 }): {
     allDeps: ReadonlyArray<any>;
     extraDepValues: T;
 };
+export {};

--- a/dist/use-extra-deps/index.js
+++ b/dist/use-extra-deps/index.js
@@ -26,18 +26,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useExtraDeps = exports.unsafeMkCallbackFn = exports.unCallbackFn = void 0;
+exports.useExtraDeps = exports.unsafeMkCallbackFn = void 0;
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 const mapValues_1 = __importDefault(require("lodash/mapValues"));
-const omitBy_1 = __importDefault(require("lodash/omitBy"));
-const pickBy_1 = __importDefault(require("lodash/pickBy"));
-const values_1 = __importDefault(require("lodash/values"));
 const React = __importStar(require("react"));
-const unCallbackFn = ({ callback }) => callback;
-exports.unCallbackFn = unCallbackFn;
-// Used only by `useSafeCallback`
 function unsafeMkCallbackFn(callback) {
-    return { callback };
+    return callback;
 }
 exports.unsafeMkCallbackFn = unsafeMkCallbackFn;
 // Hook used to help avoid pitfalls surrounding misuse of objects and arrays in
@@ -56,15 +50,13 @@ exports.unsafeMkCallbackFn = unsafeMkCallbackFn;
 //
 function useExtraDeps(deps, extraDeps) {
     const [run, setRun] = React.useState(Symbol());
-    const nonFnsRef = React.useRef(null);
-    const fns = (0, mapValues_1.default)((0, pickBy_1.default)(extraDeps, dep => 'callback' in dep), fn => fn.callback);
-    const nonFns = (0, omitBy_1.default)(extraDeps, dep => 'callback' in dep);
+    const extraDepsRef = React.useRef(null);
     const hasChange = () => {
-        if (nonFnsRef.current === null || nonFnsRef.current === undefined) {
+        if (extraDepsRef.current === null || extraDepsRef.current === undefined) {
             return true;
         }
-        for (const key in nonFns) {
-            if (!nonFns[key].comparator(nonFns[key].value, nonFnsRef.current[key].value)) {
+        for (const key in extraDeps) {
+            if (!extraDeps[key].comparator(extraDeps[key].value, extraDepsRef.current[key].value)) {
                 return true;
             }
         }
@@ -72,11 +64,11 @@ function useExtraDeps(deps, extraDeps) {
     };
     if (hasChange()) {
         setRun(Symbol());
-        nonFnsRef.current = nonFns;
+        extraDepsRef.current = extraDeps;
     }
     return {
-        allDeps: [...deps, ...(0, values_1.default)(fns), run],
-        extraDepValues: Object.assign(Object.assign({}, (0, mapValues_1.default)(nonFns, ({ value }) => value)), fns)
+        allDeps: [...deps, run],
+        extraDepValues: (0, mapValues_1.default)(extraDeps, ({ value }) => value)
     };
 }
 exports.useExtraDeps = useExtraDeps;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freckle/react-hooks",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "React hooks used at Freckle",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export {useSafeCallback, useSafeCallbackExtraDeps} from './use-safe-callback'
 
 export {usePrevious} from './use-previous'
 
-export {unCallbackFn, unsafeMkCallbackFn, useExtraDeps} from './use-extra-deps'
+export {unsafeMkCallbackFn, useExtraDeps} from './use-extra-deps'
 
 export {
   useSafeImperativeHandle,

--- a/src/use-safe-callback/index.test.tsx
+++ b/src/use-safe-callback/index.test.tsx
@@ -14,30 +14,31 @@ describe('useSafeCallback', () => {
     let cbF = f
     // f stays the same reference when prop stays the same
     rerender(<A p1={0} />)
-    expect(cbF.callback).toBe(f.callback)
+    expect(cbF).toBe(f)
     cbF = f
 
     // f changes reference when prop changes
     rerender(<A p1={1} />)
-    expect(cbF.callback).not.toBe(f.callback)
+    expect(cbF).not.toBe(f)
   })
   it('works with multiple arity function', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let f: any
-    const A = ({p1}: {p1: number}) => {
-      f = useSafeCallback(() => (_a, _b) => p1, [p1])
+    const A = ({ p1 }: { p1: number }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      f = useSafeCallback(() => (_a: any, _b: any) => p1, [p1])
       return null
     }
     const {rerender} = render(<A p1={0} />)
     let cbF = f
     // f stays the same reference when prop stays the same
     rerender(<A p1={0} />)
-    expect(cbF.callback).toBe(f.callback)
+    expect(cbF).toBe(f)
     cbF = f
 
     // f changes reference when prop changes
     rerender(<A p1={1} />)
-    expect(cbF.callback).not.toBe(f.callback)
+    expect(cbF).not.toBe(f)
   })
 })
 
@@ -66,12 +67,12 @@ describe('useSafeCallbackExtraDeps', () => {
 
     // f stays the same reference when prop stays the same
     rerender(<A p1={arr1} />)
-    expect(cbF.callback).toBe(f.callback)
+    expect(cbF).toBe(f)
     cbF = f
 
     // f changes reference when prop changes
     rerender(<A p1={arr2} />)
-    expect(cbF.callback).not.toBe(f.callback)
+    expect(cbF).not.toBe(f)
   })
 
   it('works with any arity function', async () => {
@@ -98,11 +99,11 @@ describe('useSafeCallbackExtraDeps', () => {
 
     // f stays the same reference when prop stays the same
     rerender(<A p1={arr1} />)
-    expect(cbF.callback).toBe(f.callback)
+    expect(cbF).toBe(f)
     cbF = f
 
     // f changes reference when prop changes
     rerender(<A p1={arr2} />)
-    expect(cbF.callback).not.toBe(f.callback)
+    expect(cbF).not.toBe(f)
   })
 })

--- a/src/use-safe-effect/index.test.tsx
+++ b/src/use-safe-effect/index.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {render} from '@testing-library/react'
 import {useSafeEffect, useSafeEffectExtraDeps} from '.'
 import {useSafeCallback} from './../use-safe-callback'
-import {CallbackFn} from '../use-extra-deps'
+import {CallbackFn, unsafeMkCallbackFn} from '../use-extra-deps'
 
 describe('useSafeEffect', () => {
   it('works with no deps', async () => {
@@ -40,7 +40,7 @@ describe('useSafeEffect', () => {
 
   it('works with only primitive deps', async () => {
     const sideEffect = jest.fn()
-    const C = ({p1, p2}: {p1: number; p2: number}) => {
+    const C = ({ p1, p2 }: { p1: number; p2: number }) => {
       useSafeEffect(() => sideEffect(p1), [p1])
       return <>{p2}</>
     }
@@ -162,12 +162,12 @@ describe('useSafeEffect', () => {
       return <C p2={p2} p3={p3} f={cbF} />
     }
     const C = ({f, p2, p3}: {f: CallbackFn<(b: number) => void>; p2: number; p3: number}) => {
-      useSafeEffectExtraDeps<{p3: number; f: (b: number) => void}>(
-        ({p3, f}) => {
+      useSafeEffectExtraDeps<{p3: number}>(
+        ({p3}) => {
           return f(p3)
         },
-        [],
-        {p3: {value: p3, comparator: (a, b) => a === b}, f}
+        [f],
+        {p3: {value: p3, comparator: (a, b) => a === b}}
       )
       return <>{p2}</>
     }

--- a/src/use-safe-imperative-handle/index.test.tsx
+++ b/src/use-safe-imperative-handle/index.test.tsx
@@ -168,11 +168,11 @@ describe('useSafeImperativeHandle', () => {
     }
 
     const C = ({f, p2, p3}: {f: CallbackFn<(b: number) => number[]>; p2: number; p3: number}) => {
-      useSafeImperativeHandleExtraDeps<{a: string}, {p3: number; f: (b: number) => number[]}>(
+      useSafeImperativeHandleExtraDeps<{a: string}, {p3: number}>(
         ref,
-        ({p3, f}) => cb(...f(p3)),
-        [],
-        {p3: {value: p3, comparator: (a, b) => a === b}, f}
+        ({p3}) => cb(...f(p3)),
+        [f],
+        {p3: {value: p3, comparator: (a, b) => a === b}}
       )
       return <>{p2}</>
     }


### PR DESCRIPTION
We can avoid some wrapping and unwrapping by using a branded type for `CallbackFn`. This lets us pass the function as a primitive dep and avoids needing to have an `unCallbackFn` because you can just call the function like normal.

This does constitute a major API change so I have bumped the major version of the lib.

This basically means we can avoid a lot of the complexity of passing these functions in as extra deps:

```typescript
// Old
const Foo = ({ cb }: { cb: CallbackFn<() => void> }) => {
  useSafeEffectExtraDeps(
    ({ cb }) => {
      cb()
    },
    [],
    { cb }
  )
  return null
}

// New
const Foo = ({ cb }: { cb: CallbackFn<() => void> }) => {
  useSafeEffect(() => {
    cb()
  }, [cb])
  return null
}  
```
Also:
```typescript
// cb: CallbackFn<() => void>

// Old
unCallbackFn(cb)()

// New
cb()
```