### PR TITLE
Introduce `noopCallback`

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,7 @@
 export type { MaybeCleanUpFn } from './types';
 export type { PrimitiveDep, CallbackFn, ExtraDeps } from './use-extra-deps';
 export { useSafeEffect, useSafeEffectExtraDeps } from './use-safe-effect';
-export { useSafeCallback, useSafeCallbackExtraDeps } from './use-safe-callback';
+export { useSafeCallback, useSafeCallbackExtraDeps, noopCallback } from './use-safe-callback';
 export { usePrevious } from './use-previous';
 export { unsafeMkCallbackFn, useExtraDeps } from './use-extra-deps';
 export { useSafeImperativeHandle, useSafeImperativeHandleExtraDeps } from './use-safe-imperative-handle';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,12 +1,13 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useSafeImperativeHandleExtraDeps = exports.useSafeImperativeHandle = exports.useExtraDeps = exports.unsafeMkCallbackFn = exports.usePrevious = exports.useSafeCallbackExtraDeps = exports.useSafeCallback = exports.useSafeEffectExtraDeps = exports.useSafeEffect = void 0;
+exports.useSafeImperativeHandleExtraDeps = exports.useSafeImperativeHandle = exports.useExtraDeps = exports.unsafeMkCallbackFn = exports.usePrevious = exports.noopCallback = exports.useSafeCallbackExtraDeps = exports.useSafeCallback = exports.useSafeEffectExtraDeps = exports.useSafeEffect = void 0;
 var use_safe_effect_1 = require("./use-safe-effect");
 Object.defineProperty(exports, "useSafeEffect", { enumerable: true, get: function () { return use_safe_effect_1.useSafeEffect; } });
 Object.defineProperty(exports, "useSafeEffectExtraDeps", { enumerable: true, get: function () { return use_safe_effect_1.useSafeEffectExtraDeps; } });
 var use_safe_callback_1 = require("./use-safe-callback");
 Object.defineProperty(exports, "useSafeCallback", { enumerable: true, get: function () { return use_safe_callback_1.useSafeCallback; } });
 Object.defineProperty(exports, "useSafeCallbackExtraDeps", { enumerable: true, get: function () { return use_safe_callback_1.useSafeCallbackExtraDeps; } });
+Object.defineProperty(exports, "noopCallback", { enumerable: true, get: function () { return use_safe_callback_1.noopCallback; } });
 var use_previous_1 = require("./use-previous");
 Object.defineProperty(exports, "usePrevious", { enumerable: true, get: function () { return use_previous_1.usePrevious; } });
 var use_extra_deps_1 = require("./use-extra-deps");

--- a/dist/use-safe-callback/index.d.ts
+++ b/dist/use-safe-callback/index.d.ts
@@ -3,3 +3,4 @@ export declare function useSafeCallback<F extends (...v: any) => any>(f: () => F
 export declare function useSafeCallbackExtraDeps<F extends (...v: any) => any, T extends Record<string, unknown>>(f: (a: T) => F, deps: ReadonlyArray<PrimitiveDep>, extraDeps: {
     [P in keyof T]: T[P] extends infer R ? ExtraDeps<R> : never;
 }): CallbackFn<F>;
+export declare const noopCallback: CallbackFn<(...args: any[]) => void>;

--- a/dist/use-safe-callback/index.js
+++ b/dist/use-safe-callback/index.js
@@ -23,7 +23,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useSafeCallbackExtraDeps = exports.useSafeCallback = void 0;
+exports.noopCallback = exports.useSafeCallbackExtraDeps = exports.useSafeCallback = void 0;
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 const React = __importStar(require("react"));
 const use_extra_deps_1 = require("./../use-extra-deps");
@@ -40,3 +40,8 @@ function useSafeCallbackExtraDeps(f, deps, extraDeps) {
     return (0, use_extra_deps_1.unsafeMkCallbackFn)(cbF);
 }
 exports.useSafeCallbackExtraDeps = useSafeCallbackExtraDeps;
+function noop() {
+    return;
+}
+// noop is a stable reference so is safe to use as a `CallbackFn`
+exports.noopCallback = (0, use_extra_deps_1.unsafeMkCallbackFn)(noop);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freckle/react-hooks",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "React hooks used at Freckle",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export type {PrimitiveDep, CallbackFn, ExtraDeps} from './use-extra-deps'
 
 export {useSafeEffect, useSafeEffectExtraDeps} from './use-safe-effect'
 
-export {useSafeCallback, useSafeCallbackExtraDeps} from './use-safe-callback'
+export {useSafeCallback, useSafeCallbackExtraDeps, noopCallback} from './use-safe-callback'
 
 export {usePrevious} from './use-previous'
 

--- a/src/use-safe-callback/index.ts
+++ b/src/use-safe-callback/index.ts
@@ -33,3 +33,10 @@ export function useSafeCallbackExtraDeps<
 
   return unsafeMkCallbackFn(cbF)
 }
+
+function noop() {
+  return
+}
+
+// noop is a stable reference so is safe to use as a `CallbackFn`
+export const noopCallback: CallbackFn<(...args: any[]) => void> = unsafeMkCallbackFn(noop)


### PR DESCRIPTION
We often use `unsafeMkCallbackFn` in client code to wrap noop functions. This exposes a function that does that wrapping so that we can remove calls to the `unsafe` function in client code