### PR TITLE
Update types/lodash library

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@testing-library/react": "^15.0.7",
     "@types/invariant": "^2.2.35",
     "@types/jest": "^27.5.0",
-    "@types/lodash": "^4.14.182",
+    "@types/lodash": "^4.17.14",
     "@types/react": "^18.0.8",
     "@types/react-dom": "^18.0.5",
     "@typescript-eslint/eslint-plugin": "^5.30.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,10 +1428,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/lodash@^4.14.182":
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.5.tgz#e6c29b58e66995d57cd170ce3e2a61926d55ee04"
-  integrity sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==
+"@types/lodash@^4.17.14":
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.14.tgz#bafc053533f4cdc5fcc9635af46a963c1f3deaff"
+  integrity sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==
 
 "@types/node@*":
   version "17.0.23"


### PR DESCRIPTION
Manually updating types/lodash library since this PR is failing: https://github.com/freckle/react-hooks/pull/177